### PR TITLE
Add lang attr to titles and links

### DIFF
--- a/content/about/default.txt
+++ b/content/about/default.txt
@@ -25,7 +25,7 @@ Que vous soyez UX, UI, UX Researcher, UX Writer, ou même dev ou chef de projet 
 ## Les valeurs
 
 * Ce site tente d'être le plus **(link: /accessibility-statement text: accessible)** possible.
-* Ce site est **(link: # text: open-source)** (link: http://creativecommons.org/licenses/by-nc-sa/4.0/ text: sous licence) (pas d’utilisation commerciale - partage dans les mêmes conditions).
+* Ce site est **(link: https://github.com/astranchet/design-accessible/ text: open-source)** (link: http://creativecommons.org/licenses/by-nc-sa/4.0/ text: sous licence) (pas d’utilisation commerciale - partage dans les mêmes conditions).
 * Ce site est **(link: https://withcabin.com/faq#how-does-cabin-protect-my-visitors text: respectueux de votre vie privée)**. 
 
 ## Les contributeurs

--- a/content/about/default.txt
+++ b/content/about/default.txt
@@ -25,8 +25,8 @@ Que vous soyez UX, UI, UX Researcher, UX Writer, ou même dev ou chef de projet 
 ## Les valeurs
 
 * Ce site tente d'être le plus **(link: /accessibility-statement text: accessible)** possible.
-* Ce site est **(link: https://github.com/astranchet/design-accessible/ text: open-source)** (link: http://creativecommons.org/licenses/by-nc-sa/4.0/ text: sous licence) (pas d’utilisation commerciale - partage dans les mêmes conditions).
-* Ce site est **(link: https://withcabin.com/faq#how-does-cabin-protect-my-visitors text: respectueux de votre vie privée)**. 
+* Ce site est **(link: https://github.com/astranchet/design-accessible/ text: open-source)** (link: http://creativecommons.org/licenses/by-nc-sa/4.0/ text: sous licence hreflang: en lang: fr) (pas d’utilisation commerciale - partage dans les mêmes conditions).
+* Ce site est **(link: https://withcabin.com/faq#how-does-cabin-protect-my-visitors text: respectueux de votre vie privée hreflang: en lang: fr)**. 
 
 ## Les contributeurs
 

--- a/content/site.txt
+++ b/content/site.txt
@@ -25,11 +25,11 @@ Quotes:
 
 - 
   citation: Nous sommes tous temporairement valides.
-  source: '(link: https://en.wikipedia.org/wiki/Cindy_Li text: Cindy Li)'
+  source: '(link: https://en.wikipedia.org/wiki/Cindy_Li text: Cindy Li hreflang: en)'
   show: 'false'
 - 
   citation: "L’accessibilité est plus qu'une checklist : c'est une facette de l’expérience utilisateur."
-  source: '(link: https://accessibility-for-teams.com/accessibility-for-ux-designers text: Accessibility for teams)'
+  source: '(link: https://accessibility-for-teams.com/accessibility-for-ux-designers text: Accessibility for teams hreflang: en)'
   show: 'true'
 - 
   citation: >
@@ -51,15 +51,15 @@ Quotes:
   show: 'false'
 - 
   citation: "L'accessibilité doit être intégrée avant le développement, dès les étapes de recherche, d'idéation et de conception."
-  source: '(link: https://almanac.httparchive.org/en/2020/accessibility#conclusion text: The Web Almanac 2020)'
+  source: '(link: https://almanac.httparchive.org/en/2020/accessibility#conclusion text: The Web Almanac 2020 hreflang: en)'
   show: 'true'
 - 
   citation: "86 % des sites ont des erreurs d'accessibilité corrigeables dès la phase de design."
-  source: '(link: https://webaim.org/projects/million/ text: The WebAIM Million)'
+  source: '(link: https://webaim.org/projects/million/ text: The WebAIM Million hreflang: en)'
   show: 'true'
 - 
   citation: "Abordez l'accessibilité comme un impératif pour une bonne expérience client, et non comme une histoire de conformité."
-  source: '(link: https://speakerdeck.com/bennoloewenberg/accessibility-in-design-systems-english?slide=9 text: Gina Balhwalker)'
+  source: '(link: https://speakerdeck.com/bennoloewenberg/accessibility-in-design-systems-english?slide=9 text: Gina Balhwalker hreflang: en)'
   show: 'true'
 - 
   citation: >

--- a/site/plugins/custom-tags/tags/link.php
+++ b/site/plugins/custom-tags/tags/link.php
@@ -7,11 +7,13 @@ return [
     'html' => function($tag) {
         if (empty($tag->lang) === false) {
             $tag->value = Url::to($tag->value, $tag->lang);
+        } else {
+            $tag->lang = $tag->hreflang;
         }
 
         return Html::a($tag->value, $tag->text, [
             'hreflang'  => $tag->hreflang,
-            'lang'      => $tag->hreflang,
+            'lang'      => $tag->lang,
             'rel'       => $tag->rel,
             'class'     => $tag->class,
             'role'      => $tag->role,

--- a/site/plugins/custom-tags/tags/link.php
+++ b/site/plugins/custom-tags/tags/link.php
@@ -10,12 +10,13 @@ return [
         }
 
         return Html::a($tag->value, $tag->text, [
-        	'hreflang'	=> $tag->hreflang,
-            'rel'    	=> $tag->rel,
-            'class' 	=> $tag->class,
-            'role'   	=> $tag->role,
-            'title'  	=> $tag->title,
-            'target' 	=> $tag->target,
+            'hreflang'  => $tag->hreflang,
+            'lang'      => $tag->hreflang,
+            'rel'       => $tag->rel,
+            'class'     => $tag->class,
+            'role'      => $tag->role,
+            'title'     => $tag->title,
+            'target'    => $tag->target,
         ]);
     }
 ];

--- a/site/snippets/ressource.php
+++ b/site/snippets/ressource.php
@@ -8,8 +8,8 @@
 	</blockquote>
 
 <?php } else { ?>
-<h3 class="card__title">
-  <a href="<?= $ressource->url() ?>" rel="external" hreflang="<?= $ressource->lang() ?>">
+<h3 class="card__title" lang="<?= $ressource->lang(); ?>">
+  <a href="<?= $ressource->url() ?>" rel="external" hreflang="<?= $ressource->lang() ?>" lang="<?= $ressource->lang() ?>">
     <?= $ressource->title() ?>
   </a>
   <span class="card__type">

--- a/site/snippets/ressource.php
+++ b/site/snippets/ressource.php
@@ -8,8 +8,8 @@
 	</blockquote>
 
 <?php } else { ?>
-<h3 class="card__title" lang="<?= $ressource->lang(); ?>">
-  <a href="<?= $ressource->url() ?>" rel="external" hreflang="<?= $ressource->lang() ?>" lang="<?= $ressource->lang() ?>">
+<h3 class="card__title">
+  <a href="<?= $ressource->url() ?>" rel="external" hreflang="<?= $ressource->lang() ?>" lang="<?= $ressource->lang() ?>" lang="<?= $ressource->lang(); ?>">
     <?= $ressource->title() ?>
   </a>
   <span class="card__type">


### PR DESCRIPTION
Should fix #22 

Exemple de code généré : 

```
<h3 class="card__title" lang="en">
  <a href="https://www.highcharts.com/blog/tutorials/accessible-descriptions-for-interactive-charts/#" rel="external" hreflang="en" lang="en">
    How to write accessible descriptions for interactive charts   </a>
  <span class="card__type">
    Article  </span>
</h3>
```

et pour du français : 
```
<h3 class="card__title" lang="fr">
  <a href="https://nota-bene.org/Dark-mode-et-accessibilite" rel="external" hreflang="fr" lang="fr">
    Darkmode et accessibilité  </a>
  <span class="card__type">
    Article  </span>
</h3>
```