### PR TITLE
Correction du problème d'encodage sur les URL dont le paramètre contient une espace

### DIFF
--- a/site/controllers/site.php
+++ b/site/controllers/site.php
@@ -37,15 +37,15 @@ return function ($page, $pages, $site, $kirby) {
 	$ressources_is_filtered = true;
 	
 	if($tag = param('phase')) {
-    	$ressources = $ressources->filterBy('phase', urldecode($tag), ',');
-    	$desc = urldecode($tag);
+    	$ressources = $ressources->filterBy('phase', rawurldecode($tag), ',');
+    	$desc = rawurldecode($tag);
   	} elseif ($tag = param('lang')) {
-    	$ressources = $ressources->filterBy('lang', urldecode($tag), ',');
+    	$ressources = $ressources->filterBy('lang', rawurldecode($tag), ',');
     	$desc = ($tag == "en") ? "Anglais" : "Français";
   	} elseif ($tag = param('thematique')) {
-    	$ressources = $ressources->filterBy('thematique', urldecode($tag), ',');
+    	$ressources = $ressources->filterBy('thematique', rawurldecode($tag), ',');
     	$ressources_title = '<b>{{ desc }}</b> : {{ count }} ressource{{ plural }}';
-    	$desc = urldecode($tag);
+    	$desc = rawurldecode($tag);
   	} else {
 		$ressources_title = '<b>{{ count }} ressource{{ plural }}</b> {{ desc }}';
   		$desc = 'sélectionnées avec amour';

--- a/site/snippets/ressource.php
+++ b/site/snippets/ressource.php
@@ -30,7 +30,7 @@
 <ul class="tags">
 	<?php foreach ($ressource->phase()->split() as $phase): ?>
     <li class="tags__item tags__item-phase">
-      <a href="<?= url(page('ressources')->url(), ['params' => ['phase' => $phase]]) ?>" class="tags__link" aria-label="Autre ressources pour la phase <?= $phase ?>">
+      <a href="<?= url(page('ressources')->url(), ['params' => ['phase' => rawurlencode($phase)]]) ?>" class="tags__link" aria-label="Autre ressources pour la phase <?= $phase ?>">
         <?= $phase ?>
       </a>
     </li>
@@ -38,7 +38,7 @@
 
   <?php foreach ($ressource->thematique()->split() as $thematique): ?>
     <li class="tags__item tags__item-thematique">
-      <a href="<?= url(page('ressources')->url(), ['params' => ['thematique' => $thematique]]) ?>" class="tags__link" aria-label="Autres ressources sur : <?= $thematique ?>">
+      <a href="<?= url(page('ressources')->url(), ['params' => ['thematique' => rawurlencode($thematique)]]) ?>" class="tags__link" aria-label="Autres ressources sur : <?= $thematique ?>">
         <?= $thematique ?>
       </a>
     </li>
@@ -46,7 +46,7 @@
 
   <?php if ($ressource->lang()->isNotEmpty()) : ?>
     <li class="tags__item tags__item-lang">
-      <a href="<?= url(page('ressources')->url(), ['params' => ['lang' => $ressource->lang()]]) ?>" class="tags__link" aria-label="Autres ressources en <?= $langs[$ressource->lang()->value()] ?>">
+      <a href="<?= url(page('ressources')->url(), ['params' => ['lang' => rawurlencode($ressource->lang())]]) ?>" class="tags__link" aria-label="Autres ressources en <?= $langs[$ressource->lang()->value()] ?>">
         <?= $langs[$ressource->lang()->value()] ?>
       </a>
     </li>


### PR DESCRIPTION
Cette PR corrige https://github.com/astranchet/design-accessible/issues/28. L'encodage est fait directement dans le lien, le validateur HTML n'y voit plus d'erreur.
